### PR TITLE
Installs status.d file for ca-certificates

### DIFF
--- a/tiny/base/run/Dockerfile
+++ b/tiny/base/run/Dockerfile
@@ -16,8 +16,8 @@ RUN mkdir -p /tiny/tmp \
     /tiny/home/nonroot \
     && export DEBIAN_FRONTEND=noninteractive \
     && apt -y update \
-    && ./install-certs.sh \
-    && ./download-and-install-package.sh
+    && ./download-and-install-package.sh \
+    && ./install-certs.sh
 
 RUN rm /tiny/etc/os-release
 ADD files/os-release /tiny/etc/os-release

--- a/tiny/base/run/README.md
+++ b/tiny/base/run/README.md
@@ -41,7 +41,7 @@ ADD . /app
 RUN cd /app && \
     go build -o test
 
-FROM cloudfoundry/tiny
+FROM cloudfoundry/run:tiny
 COPY --from=build-env /app/test /test
 
 ENTRYPOINT ["/test"]

--- a/tiny/base/run/install-certs.sh
+++ b/tiny/base/run/install-certs.sh
@@ -2,16 +2,13 @@
 
 set -eu -o pipefail
 
-CERT_TMPDIR=$(mktemp -d)
-apt download ca-certificates
-ar -x ca-certificates*.deb data.tar.xz
-tar -xf data.tar.xz -C "${CERT_TMPDIR}" ./usr/share/ca-certificates
-tar -xf data.tar.xz -C /tiny/ ./usr/share/doc/ca-certificates/copyright
-
+CERTS_DIR=/tiny/usr/share/ca-certificates
 CERT_FILE=/tiny/etc/ssl/certs/ca-certificates.crt
 mkdir -p $(dirname $CERT_FILE)
 
-CERTS=$(find "${CERT_TMPDIR}/usr/share/ca-certificates" -type f | sort)
+CERTS=$(find "${CERTS_DIR}" -type f | sort)
 for cert in ${CERTS}; do
   cat "${cert}" >> "${CERT_FILE}"
 done
+
+rm -rf "${CERTS_DIR}"

--- a/tiny/base/run/packagelist
+++ b/tiny/base/run/packagelist
@@ -1,6 +1,7 @@
+base-files
+ca-certificates
 libc6
 libssl1.1
-openssl
-base-files
 netbase
+openssl
 tzdata

--- a/tiny/base/run/tests/test.bats
+++ b/tiny/base/run/tests/test.bats
@@ -13,6 +13,14 @@ setup() {
     check_file_exists /etc/ssl/certs/ca-certificates.crt
 }
 
+@test "the ca-certificates directory has been removed" {
+    run docker cp ${container_id}:/usr/share/ca-certificates -
+    [ "$status" -eq 1 ]
+}
+
+@test "the ca-certificates dpkg status.d exists" {
+    check_file_exists "/var/lib/dpkg/status.d/ca-certificates"
+}
 @test "the base-files dpkg status.d exists" {
     check_file_exists "/var/lib/dpkg/status.d/base-files"
 }


### PR DESCRIPTION
The `status.d` entry for ca-certificates package is missing from Tiny.
As a result the apt database of installed packages is not complete.

This PR ensures the `status.d` entry for ca-certificates is present, so the apt database now includes details of all installed packages.