### PR TITLE
Explicit DockerHub Host

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 # Metadata for Paketo Build/Run Stack Images
 
-The following build/run stack images are supported:  
-**Base**:  
-	- `gcr.io/paketo-buildpacks/[build/run]:base-cnb`  
-	- `paketobuildpacks/[build/run]:base-cnb`  
-**Full**:   
-	- `gcr.io/paketo-buildpacks/[build/run]:full-cnb-cf`   
-	- `paketobuildpacks/[build/run]:full-cnb-cf`  
-**Tiny**:  
-	- `gcr.io/paketo-buildpacks/[build/run]:tiny-cnb`  
-	- `paketobuildpacks/[build/run]:tiny-cnb` 
+The following build/run stack images are supported:
+**Base**:
+	- `gcr.io/paketo-buildpacks/[build/run]:base-cnb`
+	- `index.docker.io/paketobuildpacks/[build/run]:base-cnb`
+**Full**:
+	- `gcr.io/paketo-buildpacks/[build/run]:full-cnb-cf`
+	- `index.docker.io/paketobuildpacks/[build/run]:full-cnb-cf`
+**Tiny**:
+	- `gcr.io/paketo-buildpacks/[build/run]:tiny-cnb`
+	- `index.docker.io/paketobuildpacks/[build/run]:tiny-cnb`
 
 ## Use Cases
 
 
-### Base (aka "bionic")  
+### Base (aka "bionic")
 Ideal for:
 - Java apps and .NET Core apps
 - Go apps that require some C libraries
-- Node.js/Python/Ruby/etc. apps **without** many native extensions 
+- Node.js/Python/Ruby/etc. apps **without** many native extensions
 
 Contains:
 - Build: ubuntu:bionic + openssl + CA certs + compilers + shell utilities


### PR DESCRIPTION
Previously, the documentation described the stack mirror address for DockerHub with the implicit hostname.  In order to be as clear as possible, this listing should have the explicit host name for DockerHub.