### PR TITLE
zlib1g

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Contains:
 ### Tiny
 Ideal for:
 - Most Go apps
+- Java [GraalVM Native Images](https://www.graalvm.org/docs/reference-manual/native-image/)
 
 Contains:
 - Build: ubuntu:bionic + openssl + CA certs + compilers + shell utilities
-- Run: distroless-like bionic + glibc + openssl + CA certs
+- Run: distroless-like bionic + glibc + openssl + CA certs + zlib1g

--- a/base/dockerfile/build/Dockerfile
+++ b/base/dockerfile/build/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && \
   libssl1.1 \
   openssl \
   xz-utils \
+  zlib1g-dev \
   && rm -rf /var/lib/apt/lists/*
 
 RUN curl -sL -o /usr/local/bin/yj https://github.com/sclevine/yj/releases/latest/download/yj-linux \

--- a/base/dockerfile/run/Dockerfile
+++ b/base/dockerfile/run/Dockerfile
@@ -5,4 +5,5 @@ RUN apt-get update && \
   ca-certificates \
   libssl1.1 \
   openssl \
+  zlib1g \
   && rm -rf /var/lib/apt/lists/*

--- a/tiny/cnb/run/Dockerfile
+++ b/tiny/cnb/run/Dockerfile
@@ -23,6 +23,8 @@ LABEL io.buildpacks.stack.mixins="[\
 \"ca-certificates\", \
 \"libssl1.1\", \
 \"openssl\", \
+\"zlib1g\", \
 \"run:ca-certificates\", \
 \"run:libssl1.1\", \
-\"run:openssl\"]"
+\"run:openssl\", \
+\"run:zlib1g\"]"

--- a/tiny/dockerfile/run/README.md
+++ b/tiny/dockerfile/run/README.md
@@ -11,6 +11,7 @@ Tiny is a base image for containers.  It is functionally equivalent to Google's 
 * base-files
 * netbase
 * tzdata
+* zlib1g
 
 ## Additional components
 

--- a/tiny/dockerfile/run/packagelist
+++ b/tiny/dockerfile/run/packagelist
@@ -5,3 +5,4 @@ libssl1.1
 netbase
 openssl
 tzdata
+zlib1g


### PR DESCRIPTION
Previously, Java applications could not run on the tiny run image.  With the advent of the [GraalVM][1] [Native Image][2] functionality, this is now a possibility.  Native Images have few, but some library dependencies.  Most of these libraries are already on the tiny run image, and two of the three that are not (`libstdc`++ and `libgcc_s`) can be statically compiled into the native image binary.  However, there is a single library dependency on `libz` that cannot be compiled into the binary.

This change adds the `zlib1g` package to the base images and the tiny run image. There are good reasons to minimize the collection of packages on base and especially tiny, but given that this library is quite commonly used and is the only barrier to Java native images on tiny I think it's a trade-off worth making.  In addition, the list of libraries required by GraalVM native images has been constant for some time, and while it's impossible to predict the future, it is currently unlikely that any further libraries would need to be added to tiny.

[1]: https://www.graalvm.org
[2]: https://www.graalvm.org/docs/reference-manual/native-image/
