### PR TITLE
Remove Runtime zlib1g

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ Ideal for:
 
 Contains:
 - Build: ubuntu:bionic + openssl + CA certs + compilers + shell utilities
-- Run: distroless-like bionic + glibc + openssl + CA certs + zlib1g
+- Run: distroless-like bionic + glibc + openssl + CA certs

--- a/tiny/cnb/run/Dockerfile
+++ b/tiny/cnb/run/Dockerfile
@@ -23,8 +23,6 @@ LABEL io.buildpacks.stack.mixins="[\
 \"ca-certificates\", \
 \"libssl1.1\", \
 \"openssl\", \
-\"zlib1g\", \
 \"run:ca-certificates\", \
 \"run:libssl1.1\", \
-\"run:openssl\", \
-\"run:zlib1g\"]"
+\"run:openssl\"]"

--- a/tiny/dockerfile/run/README.md
+++ b/tiny/dockerfile/run/README.md
@@ -11,7 +11,6 @@ Tiny is a base image for containers.  It is functionally equivalent to Google's 
 * base-files
 * netbase
 * tzdata
-* zlib1g
 
 ## Additional components
 

--- a/tiny/dockerfile/run/packagelist
+++ b/tiny/dockerfile/run/packagelist
@@ -5,4 +5,3 @@ libssl1.1
 netbase
 openssl
 tzdata
-zlib1g


### PR DESCRIPTION
Previously, `zlib1g` was added both to build and run `tiny` images.  The use-case that necessitated that has since been improved to only require it at build time.  This change removes it from the run image.
