### PR TITLE
Install jq 1.6 before creating stacks in workflows

### DIFF
--- a/.github/workflows/base-build-test.yml
+++ b/.github/workflows/base-build-test.yml
@@ -28,6 +28,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Install jq 1.6
+      run: |
+        sudo curl -sSLf -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+        sudo chmod a+x /usr/local/bin/jq
+
     - name: Docker login
       run: |
         docker login -u ${{ secrets.PAKETO_DOCKER_USER }} --password-stdin \

--- a/.github/workflows/full-build-test.yml
+++ b/.github/workflows/full-build-test.yml
@@ -28,6 +28,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Install jq 1.6
+      run: |
+        sudo curl -sSLf -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+        sudo chmod a+x /usr/local/bin/jq
+
     - uses: google-github-actions/setup-gcloud@master
       with:
         version: '270.0.0'

--- a/.github/workflows/tiny-build-test.yml
+++ b/.github/workflows/tiny-build-test.yml
@@ -26,6 +26,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Install jq 1.6
+      run: |
+        sudo curl -sSLf -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+        sudo chmod a+x /usr/local/bin/jq
+
     - name: Download BATS
       run: |
         curl -sL https://github.com/bats-core/bats-core/archive/master.zip --output master.zip


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Upgrade jq on github runner from 1.5 to 1.6 to fix failing workflow.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
