### PR TITLE
Sort base image tags by version

### DIFF
--- a/.github/workflows/tiny-build-test.yml
+++ b/.github/workflows/tiny-build-test.yml
@@ -70,7 +70,7 @@ jobs:
 
         build_base_image_tag="$(sudo skopeo inspect docker://${build_base_image} | \
           jq -r '.RepoTags' | grep "[0-9]" | grep "base" | \
-          grep -v "cnb" | sort | tail -n 1 | sed 's/["|,| ]//g')"
+          grep -v "cnb" | sort --version-sort | tail -n 1 | sed 's/["|,| ]//g')"
 
         echo "::set-output name=build_base_image_tag::${build_base_image_tag}"
 


### PR DESCRIPTION
Co-authored-by: Brayan Henao <bhenao@vmware.com>

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Fixes issue where the last bunch of [releases of the tiny stack](https://github.com/paketo-buildpacks/tiny-stack-release/releases) all say the build CNB image was based off `paketobuildpacks/build:1.0.9-base`  

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
