### PR TITLE
Move stack RC images to paketotesting

### DIFF
--- a/.github/workflows/base-build-test.yml
+++ b/.github/workflows/base-build-test.yml
@@ -15,10 +15,10 @@ on:
       - 'packages/base/**'
 
 env:
-  BUILD_BASE_TAG: paketobuildpacks/build-rc:${{ github.sha }}-base
-  BUILD_CNB_TAG: paketobuildpacks/build-rc:${{ github.sha }}-base-cnb
-  RUN_BASE_TAG: paketobuildpacks/run-rc:${{ github.sha }}-base
-  RUN_CNB_TAG: paketobuildpacks/run-rc:${{ github.sha }}-base-cnb
+  BUILD_BASE_TAG: paketotesting/build-rc:${{ github.sha }}-base
+  BUILD_CNB_TAG: paketotesting/build-rc:${{ github.sha }}-base-cnb
+  RUN_BASE_TAG: paketotesting/run-rc:${{ github.sha }}-base
+  RUN_CNB_TAG: paketotesting/run-rc:${{ github.sha }}-base-cnb
   STACK_ID: io.buildpacks.stacks.bionic
 
 jobs:
@@ -35,14 +35,14 @@ jobs:
 
       - name: Docker login
         run: |
-          docker login -u ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }} --password-stdin \
-            < <(echo "${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}")
+          docker login -u ${{ secrets.PAKETO_TESTING_DOCKERHUB_USERNAME }} --password-stdin \
+            < <(echo "${{ secrets.PAKETO_TESTING_DOCKERHUB_PASSWORD }}")
 
       - name: Build and push images
         uses: paketo-buildpacks/stacks/actions/create-stack@main
         with:
-          build_destination: paketobuildpacks/build-rc
-          run_destination: paketobuildpacks/run-rc
+          build_destination: paketotesting/build-rc
+          run_destination: paketotesting/run-rc
           version: ${{ github.sha }}
           stack: base
           stacks_dir: ${GITHUB_WORKSPACE}

--- a/.github/workflows/full-build-test.yml
+++ b/.github/workflows/full-build-test.yml
@@ -15,10 +15,10 @@ on:
       - 'packages/full/**'
 
 env:
-  BUILD_BASE_TAG: paketobuildpacks/build-rc:${{ github.sha }}-full
-  BUILD_CNB_TAG: paketobuildpacks/build-rc:${{ github.sha }}-full-cnb
-  RUN_BASE_TAG: paketobuildpacks/run-rc:${{ github.sha }}-full
-  RUN_CNB_TAG: paketobuildpacks/run-rc:${{ github.sha }}-full-cnb
+  BUILD_BASE_TAG: paketotesting/build-rc:${{ github.sha }}-full
+  BUILD_CNB_TAG: paketotesting/build-rc:${{ github.sha }}-full-cnb
+  RUN_BASE_TAG: paketotesting/run-rc:${{ github.sha }}-full
+  RUN_CNB_TAG: paketotesting/run-rc:${{ github.sha }}-full-cnb
   STACK_ID: io.buildpacks.stacks.bionic
 
 jobs:
@@ -30,8 +30,8 @@ jobs:
 
       - name: Docker login
         run: |
-          docker login -u ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }} --password-stdin \
-            < <(echo "${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}")
+          docker login -u ${{ secrets.PAKETO_TESTING_DOCKERHUB_USERNAME }} --password-stdin \
+            < <(echo "${{ secrets.PAKETO_TESTING_DOCKERHUB_PASSWORD }}")
 
       - name: Setup Go
         uses: actions/setup-go@v1
@@ -41,8 +41,8 @@ jobs:
       - name: Build and push images
         uses: paketo-buildpacks/stacks/actions/create-stack@main
         with:
-          build_destination: paketobuildpacks/build-rc
-          run_destination: paketobuildpacks/run-rc
+          build_destination: paketotesting/build-rc
+          run_destination: paketotesting/run-rc
           version: ${{ github.sha }}
           stack: full
           stacks_dir: ${GITHUB_WORKSPACE}

--- a/.github/workflows/tiny-build-test.yml
+++ b/.github/workflows/tiny-build-test.yml
@@ -14,9 +14,9 @@ on:
       - 'bionic/cnb/build/Dockerfile'
 
 env:
-  RUN_BASE_TAG: paketobuildpacks/run-rc:${{ github.sha }}-tiny
-  RUN_CNB_TAG: paketobuildpacks/run-rc:${{ github.sha }}-tiny-cnb
-  BUILD_CNB_TAG: paketobuildpacks/build-rc:${{ github.sha }}-tiny-cnb
+  RUN_BASE_TAG: paketotesting/run-rc:${{ github.sha }}-tiny
+  RUN_CNB_TAG: paketotesting/run-rc:${{ github.sha }}-tiny-cnb
+  BUILD_CNB_TAG: paketotesting/build-rc:${{ github.sha }}-tiny-cnb
   STACK_ID: io.paketo.stacks.tiny
 
 jobs:
@@ -33,14 +33,14 @@ jobs:
 
       - name: Docker login
         run: |
-          docker login -u ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }} --password-stdin \
-            < <(echo "${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}")
+          docker login -u ${{ secrets.PAKETO_TESTING_DOCKERHUB_USERNAME }} --password-stdin \
+            < <(echo "${{ secrets.PAKETO_TESTING_DOCKERHUB_PASSWORD }}")
 
       - name: Build and push images
         uses: paketo-buildpacks/stacks/actions/create-stack@main
         with:
-          build_destination: paketobuildpacks/build-rc
-          run_destination: paketobuildpacks/run-rc
+          build_destination: paketotesting/build-rc
+          run_destination: paketotesting/run-rc
           version: ${{ github.sha }}
           stack: tiny
           stacks_dir: ${GITHUB_WORKSPACE}


### PR DESCRIPTION
## Summary
Move RC image to the `paketotesting` dockerhub user

Depends on:
https://github.com/paketo-buildpacks/base-stack-release/pull/19
https://github.com/paketo-buildpacks/full-stack-release/pull/26
https://github.com/paketo-buildpacks/tiny-stack-release/pull/24

## Use Cases
Keeps non-production images out of `paketobuildpacks`

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
