### PR TITLE
use skopeo login for docker login

### DIFF
--- a/.github/workflows/test-create-stack.yml
+++ b/.github/workflows/test-create-stack.yml
@@ -25,9 +25,11 @@ jobs:
           go-version: 1.16
 
       - name: Docker login
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.PAKETO_TESTING_DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.PAKETO_TESTING_DOCKERHUB_PASSWORD }}
         run: |
-          docker login -u ${{ secrets.PAKETO_TESTING_DOCKERHUB_USERNAME }} --password-stdin \
-            < <(echo '${{ secrets.PAKETO_TESTING_DOCKERHUB_PASSWORD }}')
+          echo "${DOCKERHUB_PASSWORD}" | sudo skopeo login --username "${DOCKERHUB_USERNAME}" --password-stdin index.docker.io
 
       - name: Run Tests
         run: |

--- a/.github/workflows/test-create-stack.yml
+++ b/.github/workflows/test-create-stack.yml
@@ -24,15 +24,13 @@ jobs:
         with:
           go-version: 1.16
 
-      - name: Docker login
+      - name: Run Tests
         env:
           DOCKERHUB_USERNAME: ${{ secrets.PAKETO_TESTING_DOCKERHUB_USERNAME }}
           DOCKERHUB_PASSWORD: ${{ secrets.PAKETO_TESTING_DOCKERHUB_PASSWORD }}
         run: |
           echo "${DOCKERHUB_PASSWORD}" | sudo skopeo login --username "${DOCKERHUB_USERNAME}" --password-stdin index.docker.io
 
-      - name: Run Tests
-        run: |
           cd create-stack
           go test ./...
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

The `create-stack` [workflow is failing](https://github.com/paketo-buildpacks/stacks/pull/78/checks?check_run_id=3124538913) on the `docker login` step. This changes the login to use `skopeo login` like we do in paketo-buildpacks/github-config.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
