### PR TITLE
Separate out the bot approval workflow

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,20 +1,62 @@
-name: Auto Approve paketo-bot PR
+name: Approve Bot PRs
 
 on:
-  pull_request:
-    branches: [ main ]
+  workflow_run:
+    workflows: ["Test create stack", "Test Release Notes", "Test USN Patch", "Test USN Update"]
+    types:
+      - completed
 
 jobs:
+  download:
+    name: Download PR Artifact
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    outputs:
+      pr-author: ${{ steps.pr-data.outputs.author }}
+      pr-number: ${{ steps.pr-data.outputs.number }}
+    steps:
+      - name: 'Download artifact'
+        uses: paketo-buildpacks/github-config/actions/pull-request/download-artifact@main
+        with:
+          name: "event-payload"
+          repo: ${{ github.repository }}
+          run_id: ${{ github.event.workflow_run.id }}
+          workspace: "/github/workspace"
+          token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+      - id: pr-data
+        run: |
+          echo "::set-output name=author::$(cat event.json | jq -r '.pull_request.user.login')"
+          echo "::set-output name=number::$(cat event.json | jq -r '.pull_request.number')"
+
   approve:
-    name: Auto Approve
-    if: ${{ github.event.pull_request.user.login == 'paketo-bot' }}
+    name: Approve Bot PRs
+    needs: download
+    if: ${{ needs.download.outputs.pr-author == 'paketo-bot' || needs.download.outputs.pr-author == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
+    - name: Check Commit Verification
+      id: unverified-commits
+      uses: paketo-buildpacks/github-config/actions/pull-request/check-unverified-commits@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        number: ${{ needs.download.outputs.pr-number }}
+
+    - name: Check for Human Commits
+      id: human-commits
+      uses: paketo-buildpacks/github-config/actions/pull-request/check-human-commits@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        number: ${{ needs.download.outputs.pr-number }}
+
     - name: Checkout
+      if: steps.human-commits.outputs.human_commits == 'false' && steps.unverified-commits.outputs.unverified_commits == 'false'
       uses: actions/checkout@v2
 
     - name: Approve
+      if: steps.human-commits.outputs.human_commits == 'false' && steps.unverified-commits.outputs.unverified_commits == 'false'
       uses: paketo-buildpacks/github-config/actions/pull-request/approve@main
       with:
         token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
-        number: ${{ github.event.number }}
+        number: ${{ needs.download.outputs.pr-number }}

--- a/.github/workflows/test-create-stack.yml
+++ b/.github/workflows/test-create-stack.yml
@@ -37,17 +37,12 @@ jobs:
           cd test/acceptance
           go test -timeout 30m ./...
 
-  approve:
-    name: Auto Approve
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
-    needs: test-create-stack
+  upload:
+    name: Upload Workflow Event Payload
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Approve
-      uses: paketo-buildpacks/github-config/actions/pull-request/approve@main
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v2
       with:
-        token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
-        number: ${{ github.event.number }}
+        name: event-payload
+        path: ${{ github.event_path }}

--- a/.github/workflows/test-release-notes.yml
+++ b/.github/workflows/test-release-notes.yml
@@ -24,17 +24,12 @@ jobs:
         cd actions/release-notes/release-notes-generator
         go test ./...
 
-  approve:
-    name: Auto Approve
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
-    needs: test-release-notes
+  upload:
+    name: Upload Workflow Event Payload
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Approve
-      uses: paketo-buildpacks/github-config/actions/pull-request/approve@main
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v2
       with:
-        token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
-        number: ${{ github.event.number }}
+        name: event-payload
+        path: ${{ github.event_path }}

--- a/.github/workflows/test-usn-patch.yml
+++ b/.github/workflows/test-usn-patch.yml
@@ -24,17 +24,12 @@ jobs:
         cd actions/usn-patch/entrypoint
         go test ./...
 
-  approve:
-    name: Auto Approve
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
-    needs: test-usn-patch
+  upload:
+    name: Upload Workflow Event Payload
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Approve
-      uses: paketo-buildpacks/github-config/actions/pull-request/approve@main
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v2
       with:
-        token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
-        number: ${{ github.event.number }}
+        name: event-payload
+        path: ${{ github.event_path }}

--- a/.github/workflows/test-usn-update.yml
+++ b/.github/workflows/test-usn-update.yml
@@ -24,17 +24,12 @@ jobs:
         cd actions/usn-update/usn-recorder
         go test ./...
 
-  approve:
-    name: Auto Approve
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
-    needs: test-usn-update
+  upload:
+    name: Upload Workflow Event Payload
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Approve
-      uses: paketo-buildpacks/github-config/actions/pull-request/approve@main
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v2
       with:
-        token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
-        number: ${{ github.event.number }}
+        name: event-payload
+        path: ${{ github.event_path }}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

We recently did this in github-config and dep-server. This adds a separate bot approval workflow for dependabot PRs (and paketo-bot still) so that we can get around the issue in which bot PRs can't be auto-approved due to token permissions.

## Use Cases
<!-- An explanation of the use cases your change enables -->

Allow bot PRs to get auto approved / merged.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
