### PR TITLE
Mark workspace directories as safe for git

### DIFF
--- a/bionic/dockerfile/build/Dockerfile
+++ b/bionic/dockerfile/build/Dockerfile
@@ -16,5 +16,7 @@ RUN echo "debconf debconf/frontend select noninteractive" | debconf-set-selectio
   apt-get -y $package_args install $packages && \
   rm -rf /var/lib/apt/lists/* /tmp/*
 
+RUN for path in /workspace /workspace/source-ws /workspace/source; do git config --system --add safe.directory "${path}"; done
+
 RUN curl -sSfL -o /usr/local/bin/yj https://github.com/sclevine/yj/releases/latest/download/yj-linux-amd64 \
   && chmod +x /usr/local/bin/yj

--- a/create-stack/test/acceptance/tiny_test.go
+++ b/create-stack/test/acceptance/tiny_test.go
@@ -215,6 +215,18 @@ nonroot:x:65532:
 
 			output, err = exec.Command("docker", "start", "-a", containerID).CombinedOutput()
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to run test app in container: %s", output))
+
+			cmd = exec.Command(
+				"docker", "run", "--rm",
+				settings.Build.BaseRef,
+				"git", "config", "--system", "--list",
+			)
+			output, err = cmd.CombinedOutput()
+			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to run container: %s", output))
+
+			Expect(string(output)).To(ContainSubstring("safe.directory=/workspace"))
+			Expect(string(output)).To(ContainSubstring("safe.directory=/workspace/source-ws"))
+			Expect(string(output)).To(ContainSubstring("safe.directory=/workspace/source"))
 		})
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Marking the popular workspace directories as safe for `git` will prevent issues running the latest versions that now check the owner of the top-level directory.

## Use Cases
<!-- An explanation of the use cases your change enables -->

On `kpack`, and maybe other platforms, the workspace directory is owned by `root` and cannot easily be changed to another user. Additionally, recent stacks now include a version of `git` that includes a check of ownership for the top-level directory in a repository. Functionally, this has meant that builds on `kpack` that include a top-level `.git` directory and run on the latest versions of the stack could fail if they invoke any `git` command.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
