### PR TITLE
Fix link to yj in bionic build Dockerfile.

### DIFF
--- a/bionic/dockerfile/build/Dockerfile
+++ b/bionic/dockerfile/build/Dockerfile
@@ -16,5 +16,5 @@ RUN echo "debconf debconf/frontend select noninteractive" | debconf-set-selectio
   apt-get -y $package_args install $packages && \
   rm -rf /var/lib/apt/lists/* /tmp/*
 
-RUN curl -sL -o /usr/local/bin/yj https://github.com/sclevine/yj/releases/latest/download/yj-linux-amd64 \
+RUN curl -sSfL -o /usr/local/bin/yj https://github.com/sclevine/yj/releases/latest/download/yj-linux-amd64 \
   && chmod +x /usr/local/bin/yj

--- a/bionic/dockerfile/build/Dockerfile
+++ b/bionic/dockerfile/build/Dockerfile
@@ -16,5 +16,5 @@ RUN echo "debconf debconf/frontend select noninteractive" | debconf-set-selectio
   apt-get -y $package_args install $packages && \
   rm -rf /var/lib/apt/lists/* /tmp/*
 
-RUN curl -sL -o /usr/local/bin/yj https://github.com/sclevine/yj/releases/latest/download/yj-linux \
+RUN curl -sL -o /usr/local/bin/yj https://github.com/sclevine/yj/releases/latest/download/yj-linux-amd64 \
   && chmod +x /usr/local/bin/yj


### PR DESCRIPTION
In #128 it was reported that `yj` is not present on recent images. This is because as of release `v5.1.0` of `yj` the name of the binary changed from `yj-linux` to `yj-linux-amd64`. Therefore the new URL is: https://github.com/sclevine/yj/releases/latest/download/yj-linux-amd64.

I don't have a great mental model of how the Dockerfile is used in the stack creation process, specifically whether this change could cause issues for any older images. I don't see how this could be a problem as the URL for `yj` is now invalid, even if re-building older images, as it references the `latest` version.

Instead of using the latest version, we could pin to a specific version, but that seems less useful.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
