### PR TITLE
Adds libexpat1 to support httpd in base builder (#147)

### DIFF
--- a/packages/base/build
+++ b/packages/base/build
@@ -3,6 +3,7 @@ ca-certificates
 curl
 git
 jq
+libexpat1
 libgmp-dev
 libssl1.1
 libyaml-0-2

--- a/packages/base/run
+++ b/packages/base/run
@@ -1,4 +1,5 @@
 ca-certificates
+libexpat1
 libssl1.1
 libyaml-0-2
 netbase


### PR DESCRIPTION
Adds missing package to support the httpd buildpack

`libexpat1` is added to both build and run for symmetry.
The difference between the sizes of the build and run images after including `libexpat1` is negligible:
| | w/ `libexpat1` | w/o `libexpat1` |
| ----- | ----- | ---- |
| Run | 88.996 MB | 88.595 MB |
| Build | 326.075 MB | 326.101 MB |